### PR TITLE
Handle self-closing root element

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -293,7 +293,7 @@ function emitEndElement(cx: XMLParseContext, qName: string): XMLParseEvent[] {
     return events;
 }
 
-// EMPTY_ELEMENT_TAG; start_element & end_element & GENERAL_STUFF, Error
+// EMPTY_ELEMENT_TAG; start_element & end_element & GENERAL_STUFF, start_element & end_element & end_document & AFTER_DOCUMENT, Error
 export function handleEmptyElementTag(cx: XMLParseContext, c: string): XMLParseEvent[] {
     let events: XMLParseEvent[] = [];
     if (c !== '>') {
@@ -302,7 +302,12 @@ export function handleEmptyElementTag(cx: XMLParseContext, c: string): XMLParseE
     const element = cx.peekElement()!;
     element.emptyElement = true;
     events = emitStartElement(cx).concat(emitEndElement(cx, element.qName));
-    cx.state = 'GENERAL_STUFF';
+    if (cx.elementLength === 0) {
+        events.push(['end_document']);
+        cx.state = 'AFTER_DOCUMENT';
+    } else {
+        cx.state = 'GENERAL_STUFF';
+    }
     return events;
 }
 

--- a/parser_test.ts
+++ b/parser_test.ts
@@ -96,6 +96,16 @@ Deno.test('SAXParser parse(string)', () => {
     assertEquals(flag, true);
 });
 
+Deno.test('SAXParser self-closing end_document', () => {
+    const parser = new SAXParser();
+    let flag = false;
+    parser.on('end_document', () => {
+        flag = true;
+    });
+    parser.parse('<hello/>');
+    assertEquals(flag, true);
+});
+
 Deno.test('marshallEvent', () => {
     class TestParser extends PullParser {
         marshallEvent(event: XMLParseEvent): PullResult {


### PR DESCRIPTION
Currently the end of the document is not detected when the root element is self-closing. A document like `<xml/>`  never emits `end_document` and never reaches `AFTER_DOCUMENT` state.

Normally `closeElement()` checks for end-of-document after a closing tag was encountered, but that function isn't used for self-closing tags. Self-closing tags are processed by `handleEmptyElementTag()` so that function has to check for the end of the document as well. The logic used is the same as in `closeElement()`.